### PR TITLE
Sanitize redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 /RUNNING_PID
 /.settings
 .DS_Store
+.env

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -469,7 +469,7 @@ class Application @Inject()
   private def safeRedirectUrl(state: String)(implicit request: RequestHeader): String = {
       // If passed in redirectUrl (state) is outside app domain, redirect to base sign-cla form instead
       // Needed to mitigate OWASP unvalidated redirects
-      val appUrl = new URL(routes.Application.signCla(Some("")).absoluteURL())
+      val appUrl = new URL(routes.Application.signCla(None).absoluteURL())
       val redirectUrl = new URL(state)
 
       if(redirectUrl.getHost() != appUrl.getHost()){

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -57,23 +57,23 @@ class Application @Inject()
     }
   }
 
-  def gitHubAppOauthCallback(code: String, state: String) = Action.async { request =>
+  def gitHubAppOauthCallback(code: String, state: String) = Action.async { implicit request =>
     gitHub.accessToken(code, gitHub.integrationClientId, gitHub.integrationClientSecret).map { accessToken =>
       val encAccessToken = crypto.encryptAES(accessToken)
-      Redirect(safeRedirectUrl(state)(request)).flashing("encAccessToken" -> encAccessToken)
+      Redirect(safeRedirectUrl(state)).flashing("encAccessToken" -> encAccessToken)
     } recover {
-      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)(request)).flashing("error" -> e.getMessage)
+      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)).flashing("error" -> e.getMessage)
       case e: Exception => InternalServerError(e.getMessage)
     }
   }
 
   // state is used for the URL to redirect to
-  def gitHubOauthCallback(code: String, state: String) = Action.async { request =>
+  def gitHubOauthCallback(code: String, state: String) = Action.async { implicit request =>
     gitHub.accessToken(code, gitHub.clientId, gitHub.clientSecret).map { accessToken =>
       val encAccessToken = crypto.encryptAES(accessToken)
-      Redirect(safeRedirectUrl(state)(request)).flashing("encAccessToken" -> encAccessToken)
+      Redirect(safeRedirectUrl(state)).flashing("encAccessToken" -> encAccessToken)
     } recover {
-      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)(request)).flashing("error" -> e.getMessage)
+      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)).flashing("error" -> e.getMessage)
       case e: Exception => InternalServerError(e.getMessage)
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -8,6 +8,7 @@
 package controllers
 
 import java.time.LocalDateTime
+import java.net.URL
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Query
@@ -59,9 +60,9 @@ class Application @Inject()
   def gitHubAppOauthCallback(code: String, state: String) = Action.async { request =>
     gitHub.accessToken(code, gitHub.integrationClientId, gitHub.integrationClientSecret).map { accessToken =>
       val encAccessToken = crypto.encryptAES(accessToken)
-      Redirect(state).flashing("encAccessToken" -> encAccessToken)
+      Redirect(safeRedirectUrl(state)(request)).flashing("encAccessToken" -> encAccessToken)
     } recover {
-      case e: utils.UnauthorizedError => Redirect(state).flashing("error" -> e.getMessage)
+      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)(request)).flashing("error" -> e.getMessage)
       case e: Exception => InternalServerError(e.getMessage)
     }
   }
@@ -70,9 +71,9 @@ class Application @Inject()
   def gitHubOauthCallback(code: String, state: String) = Action.async { request =>
     gitHub.accessToken(code, gitHub.clientId, gitHub.clientSecret).map { accessToken =>
       val encAccessToken = crypto.encryptAES(accessToken)
-      Redirect(state).flashing("encAccessToken" -> encAccessToken)
+      Redirect(safeRedirectUrl(state)(request)).flashing("encAccessToken" -> encAccessToken)
     } recover {
-      case e: utils.UnauthorizedError => Redirect(state).flashing("error" -> e.getMessage)
+      case e: utils.UnauthorizedError => Redirect(safeRedirectUrl(state)(request)).flashing("error" -> e.getMessage)
       case e: Exception => InternalServerError(e.getMessage)
     }
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -465,6 +465,19 @@ class Application @Inject()
     routes.Application.gitHubOauthCallback("", "").absoluteURL(request.secure).stripSuffix("?code=&state=")
   }
 
+  private def safeRedirectUrl(state: String)(implicit request: RequestHeader): String = {
+      // If passed in redirectUrl (state) is outside app domain, redirect to base sign-cla form instead
+      // Needed to mitigate OWASP unvalidated redirects
+      val appUrl = new URL(routes.Application.signCla(Some("")).absoluteURL())
+      var redirectUrl = new URL(state)
+
+      if(redirectUrl.getHost() != appUrl.getHost()){
+        redirectUrl = appUrl
+      }
+
+      redirectUrl.toString()
+  }
+
   case class AlreadyExistsException(claSignature: ClaSignature) extends Exception
 
   case object NeedsAuth extends Exception

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -470,13 +470,14 @@ class Application @Inject()
       // If passed in redirectUrl (state) is outside app domain, redirect to base sign-cla form instead
       // Needed to mitigate OWASP unvalidated redirects
       val appUrl = new URL(routes.Application.signCla(Some("")).absoluteURL())
-      var redirectUrl = new URL(state)
+      val redirectUrl = new URL(state)
 
       if(redirectUrl.getHost() != appUrl.getHost()){
-        redirectUrl = appUrl
+        appUrl.toString()
       }
-
-      redirectUrl.toString()
+      else {
+        redirectUrl.toString()
+      }
   }
 
   case class AlreadyExistsException(claSignature: ClaSignature) extends Exception

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ libraryDependencies ++= Seq(
   ws,
   filters,
 
-  "com.fasterxml.jackson.core" % "jackson-core"                    % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-annotations"             % "2.9.7",
-  "com.fasterxml.jackson.core" % "jackson-databind"                % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-core"                    % "2.9.8",
+  "com.fasterxml.jackson.core" % "jackson-annotations"             % "2.9.8",
+  "com.fasterxml.jackson.core" % "jackson-databind"                % "2.9.8",
   "org.apache.commons"         % "commons-compress"                % "1.18",
   "com.google.guava"           % "guava"                           % "27.0-jre",
   "org.bouncycastle"           % "bcprov-jdk15on"                  % "1.60",


### PR DESCRIPTION
The incoming redirect url (state parameter) on calls to the github_oauth_callback function need to be sanitized before automatically redirecting (i.e., OWASP unvalidated redirects).

For example, the following URL could be used to send someone to a malicious site and trick the user into interacting with the attacker :
https://example.com/_github_oauth_callback?code=x&state=https://malicious.com

To avoid this, we sanitize the incoming redirect from the state parameter to allow only redirects from the app's own domain otherwise we send the user to the base CLA signing page instead.

Results from a malicious and allowed URL below:
```
~/ curl -i "http://0.0.0.0:9000/_github_oauth_callback?code=x&state=http://malicious.com"
HTTP/1.1 303 See Other
Location: http://0.0.0.0:9000/sign-cla?prUrl=
Set-Cookie: PLAY_FLASH=eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImVycm9yIjoiVGhlIGNvZGUgcGFzc2VkIGlzIGluY29ycmVjdCBvciBleHBpcmVkLiJ9LCJuYmYiOjE1NDk2NDgwNDksImlhdCI6MTU0OTY0ODA0OX0.wCVZq8Ep_PYB1Y5hIbbBd-ksZZ5USks9Kwp1xn_N9Nk; SameSite=Lax; Path=/; HTTPOnly
Date: Fri, 08 Feb 2019 17:47:29 GMT
Content-Length: 0

~/ curl -i "http://0.0.0.0:9000/_github_oauth_callback?code=x&state=http://0.0.0.0:9000/sign-cla?prUrl=https://github.com/amateurhuman-test/test-repo/pull/1"
HTTP/1.1 303 See Other
Location: http://0.0.0.0:9000/sign-cla?prUrl=https://github.com/amateurhuman-test/test-repo/pull/1
Set-Cookie: PLAY_FLASH=eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImVycm9yIjoiVGhlIGNvZGUgcGFzc2VkIGlzIGluY29ycmVjdCBvciBleHBpcmVkLiJ9LCJuYmYiOjE1NDk2NDgxMjQsImlhdCI6MTU0OTY0ODEyNH0.nUfH2zfxqlS-LKPv6Vcq3Y7tBEHb0v5sOlZUZARtm18; SameSite=Lax; Path=/; HTTPOnly
Date: Fri, 08 Feb 2019 17:48:44 GMT
Content-Length: 0
```