### PR TITLE
Update access token endpoint

### DIFF
--- a/app/utils/GitHub.scala
+++ b/app/utils/GitHub.scala
@@ -111,7 +111,7 @@ class GitHub @Inject() (configuration: Configuration, ws: WSClient, messagesApi:
   }
 
   def installationAccessTokens(installationId: Int): Future[JsValue] = {
-    val (ws, claim) = jwtWs(s"installations/$installationId/access_tokens")
+    val (ws, claim) = jwtWs(s"app/installations/$installationId/access_tokens")
 
     ws.post(claim.toJsValue()).flatMap(created)
   }


### PR DESCRIPTION
See https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/

Only requires an API endpoint update, no changes to the argument signature.